### PR TITLE
fix: recoil 상태 유지 - #31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-scripts": "5.0.1",
         "react-webcam": "^7.0.1",
         "recoil": "^0.7.7",
+        "recoil-persist": "^4.2.0",
         "styled-components": "^5.3.9",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -14531,6 +14532,14 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/recoil-persist": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-4.2.0.tgz",
+      "integrity": "sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
       }
     },
     "node_modules/recursive-readdir": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-scripts": "5.0.1",
     "react-webcam": "^7.0.1",
     "recoil": "^0.7.7",
+    "recoil-persist": "^4.2.0",
     "styled-components": "^5.3.9",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/src/atoms/index.ts
+++ b/src/atoms/index.ts
@@ -1,5 +1,8 @@
 import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
 import { SelectedProps } from '../api/types';
+
+const { persistAtom } = recoilPersist();
 
 export const selectedAtom = atom<SelectedProps>({
   key: 'selected',
@@ -10,4 +13,5 @@ export const selectedAtom = atom<SelectedProps>({
     travel: '',
     photo: '',
   },
+  effects_UNSTABLE: [persistAtom],
 });

--- a/src/atoms/index.ts
+++ b/src/atoms/index.ts
@@ -2,7 +2,10 @@ import { atom } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
 import { SelectedProps } from '../api/types';
 
-const { persistAtom } = recoilPersist();
+const { persistAtom } = recoilPersist({
+  key: 'selected-persist',
+  storage: sessionStorage,
+});
 
 export const selectedAtom = atom<SelectedProps>({
   key: 'selected',

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -2,8 +2,17 @@ import styled from 'styled-components';
 import mainImage from '../assets/main.png';
 import LogoImage from '../assets/logo.png';
 import { Link } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useResetRecoilState } from 'recoil';
+import { selectedAtom } from '../atoms';
 
 function Home() {
+  const resetSelected = useResetRecoilState(selectedAtom);
+
+  useEffect(() => {
+    resetSelected();
+  }, []);
+
   return (
     <Body>
       <Image src={mainImage} alt="main-character" />

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -107,8 +107,8 @@ function Result() {
           </SaleContainer>
 
           <SaveShareButtonContainer>
-            <SaveShareButton 
-              bgColor="#379100" 
+            <SaveShareButton
+              bgColor="#379100"
               onClick={() =>
                 handleImageDownload({
                   src: `${getProductImage()}`,
@@ -189,8 +189,8 @@ const SaleButton = styled.button<{ value: string; active: boolean }>`
   font-size: 18px;
   font-weight: 600;
   padding: 14px 32px;
-  background: ${(props) => (props.active ? 'var(--primary)' : 'var(--grey)')};
-  color: ${(props) => (props.active ? 'var(--white)' : 'var(--black)')};
+  background: ${(props) => (props.active ? 'var(--grey)' : 'var(--primary)')};
+  color: ${(props) => (props.active ? 'var(--black)' : 'var(--white)')};
   cursor: pointer;
   border-style: none;
   ${(props) => props.value === 'origin' && 'border-top-left-radius: 10px'};

--- a/src/pages/select.tsx
+++ b/src/pages/select.tsx
@@ -6,11 +6,10 @@ import FirstStep from '../components/selectItem/FirstStep';
 import SecondStep from '../components/selectItem/SecondStep';
 import ThirdStep from '../components/selectItem/ThirdStep';
 import FourthStep from '../components/selectItem/FourthStep';
-import { useRecoilState } from 'recoil';
-import { selectedAtom } from '../atoms';
 import WebcamCapture from '../components/WebcamCapture';
 import ImageFileUpload from '../components/ImageUpload';
 import { SelectedProps } from '../api/types';
+import { useNavigate } from 'react-router-dom';
 
 interface ButtonProps {
   label?: string;
@@ -24,8 +23,9 @@ const PERCENTAGE = 100 / STEP;
 const steps = ['season', 'weather', 'feel', 'travel', 'photo'];
 
 const Select = () => {
+  const navigate = useNavigate();
+
   const [currentStep, setCurrentStep] = useState<number>(PERCENTAGE);
-  const [selectedState, setSelectedState] = useRecoilState(selectedAtom);
   const [uploadType, setUploadType] = useState('');
 
   const isActivePrevBtn = currentStep !== PERCENTAGE;
@@ -54,7 +54,7 @@ const Select = () => {
 
   return (
     <Container>
-      <HeaderLogo src={headerLogo} />
+      <HeaderLogo src={headerLogo} onClick={() => navigate('/')} />
       <Line
         percent={currentStep}
         strokeWidth={3}
@@ -118,6 +118,7 @@ export default Select;
 
 const HeaderLogo = styled.img`
   width: 17px;
+  cursor: pointer;
 `;
 
 const ButtonType = {


### PR DESCRIPTION
## fix: recoil 상태 유지 - #31
Resolve #31 

## summary
- recoil로 관리되는 값이 새로고침을 하면 날라가기 때문에, 결과 페이지에서 새로고침 시 터지는 이슈가 있었습니다.
- 문제를 해결하고자 recoil-persist로 선택지 값을 세션스토리지에 저장했고, 홈으로 이동 시 해당 값을 초기화시켜 테스트를 새로 시작할 때는 값이 유지되지 않도록 했습니다.

## Check List
- [x] PR 제목 commit convention에 맞게 작성
- [x] 최신 상태를 반영하고 있는지 확인
- [x] assignees & label 지정 
- [x] 웃으면서 하고 있는지 확인
- [x] 지금 행복한지 확인
