### PR TITLE
refact: select 페이지 라우팅 및 리팩토링- #38

### DIFF
--- a/src/components/SelectItem.tsx
+++ b/src/components/SelectItem.tsx
@@ -9,7 +9,7 @@ interface SelectItemProps {
   step: number;
 }
 
-const SelectItem = ({ step = 1 }: SelectItemProps) => {
+const SelectItem = ({ step }: SelectItemProps) => {
   const stepName = SELECT_OPTIONS[step - 1].name as keyof SelectedProps;
 
   const [selectedState, setSelectedState] = useRecoilState(selectedAtom);
@@ -20,7 +20,7 @@ const SelectItem = ({ step = 1 }: SelectItemProps) => {
     } = e;
 
     setSelectedState((prev) => {
-      const newObj = { ...prev, stepName: value };
+      const newObj = { ...prev, [stepName]: value };
       return newObj;
     });
   };

--- a/src/components/SelectItem.tsx
+++ b/src/components/SelectItem.tsx
@@ -1,0 +1,134 @@
+import styled from 'styled-components';
+import { FormEvent } from 'react';
+import { useRecoilState } from 'recoil';
+import { selectedAtom } from '../atoms';
+import { SELECT_OPTIONS } from '../static/select';
+import { SelectedProps } from '../api/types';
+
+interface SelectItemProps {
+  step: number;
+}
+
+const SelectItem = ({ step = 1 }: SelectItemProps) => {
+  const stepName = SELECT_OPTIONS[step - 1].name as keyof SelectedProps;
+
+  const [selectedState, setSelectedState] = useRecoilState(selectedAtom);
+
+  const handleSelectItem = (e: FormEvent<HTMLButtonElement>) => {
+    const {
+      currentTarget: { value },
+    } = e;
+
+    setSelectedState((prev) => {
+      const newObj = { ...prev, stepName: value };
+      return newObj;
+    });
+  };
+
+  return (
+    <>
+      <SubTitle>{SELECT_OPTIONS[step - 1].subTitle}</SubTitle>
+      <Title>{SELECT_OPTIONS[step - 1].title}</Title>
+      <SelectContainer>
+        <Item
+          id="1"
+          value={SELECT_OPTIONS[step - 1].item1.value}
+          onClick={handleSelectItem}
+          selected={
+            selectedState[stepName] === SELECT_OPTIONS[step - 1].item1.value
+          }
+        >
+          {SELECT_OPTIONS[step - 1].item1.text}
+        </Item>
+        <Item
+          id="2"
+          value={SELECT_OPTIONS[step - 1].item2.value}
+          onClick={handleSelectItem}
+          selected={
+            selectedState[stepName] === SELECT_OPTIONS[step - 1].item2.value
+          }
+        >
+          {SELECT_OPTIONS[step - 1].item2.text}
+        </Item>
+        <Item
+          id="3"
+          value={SELECT_OPTIONS[step - 1].item3.value}
+          onClick={handleSelectItem}
+          selected={
+            selectedState[stepName] === SELECT_OPTIONS[step - 1].item3.value
+          }
+        >
+          {SELECT_OPTIONS[step - 1].item3.text}
+        </Item>
+        <Item
+          id="4"
+          value={SELECT_OPTIONS[step - 1].item4.value}
+          onClick={handleSelectItem}
+          selected={
+            selectedState[stepName] === SELECT_OPTIONS[step - 1].item4.value
+          }
+        >
+          {SELECT_OPTIONS[step - 1].item4.text}
+        </Item>
+      </SelectContainer>
+    </>
+  );
+};
+
+export default SelectItem;
+
+const SubTitle = styled.div`
+  display: flex;
+  align-items: center;
+  text-align: center;
+  color: var(--sub-black);
+
+  font-style: normal;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 24px;
+
+  margin-top: 48px;
+`;
+
+const Title = styled.div`
+  font-size: 24px;
+  font-weight: 400;
+  line-height: 24px;
+  letter-spacing: 0em;
+  text-align: center;
+  margin: 10px 0 59px 0;
+
+  color: var(--black);
+`;
+
+const SelectContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Item = styled.button<{ selected: boolean }>`
+  width: 332px;
+  height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: ${(props) =>
+    props.selected ? 'var(--primary)' : 'var(--white)'};
+  color: ${(props) => (props.selected ? 'var(--white)' : 'var(--secondary)')};
+  box-shadow: 0px 2px 7px rgba(0, 0, 0, 0.15);
+  border-radius: 40px;
+  outline: none;
+  border: none;
+  cursor: pointer;
+  margin: 16px 0;
+  font-family: 'Noto Sans KR';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 24px;
+
+  &:hover {
+    border: 2px solid var(--primary);
+  }
+`;

--- a/src/components/router.tsx
+++ b/src/components/router.tsx
@@ -9,7 +9,7 @@ function Router() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/result" element={<Result />} />
-        <Route path="/select" element={<Select />} />
+        <Route path="/select/:step" element={<Select />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -23,7 +23,7 @@ function Home() {
           나와 닮은 귀여운 제주 못나니 <br />
           농산물 캐릭터를 찾아보세요!
         </Description>
-        <Button to="/select">닮은꼴 찾으러 가기</Button>
+        <Button to="/select/1">닮은꼴 찾으러 가기</Button>
       </IntroContainer>
     </Body>
   );

--- a/src/pages/select.tsx
+++ b/src/pages/select.tsx
@@ -9,6 +9,7 @@ import SelectItem from '../components/SelectItem';
 import { useRecoilValue } from 'recoil';
 import { selectedAtom } from '../atoms';
 
+//TODO: static으로 빼기
 const TOTAL_STEPS = 5;
 const PERCENTAGE = 100 / TOTAL_STEPS;
 const SELECTED_STEPS = ['season', 'weather', 'feel', 'travel', 'photo'];
@@ -16,28 +17,13 @@ const SELECTED_STEPS = ['season', 'weather', 'feel', 'travel', 'photo'];
 const Select = () => {
   const navigate = useNavigate();
   const { step } = useParams();
-  const [curStep, setCurStep] = useState(Number(step));
   const selectedState = useRecoilValue(selectedAtom);
-
-  const [curPercent, setCurPercent] = useState(PERCENTAGE);
-
-  const handlePrevStep = () => {
-    setCurStep((prev) => (prev === 1 ? 1 : prev - 1));
-    setCurPercent(
-      curPercent > PERCENTAGE ? curPercent - PERCENTAGE : curPercent,
-    );
-  };
-
-  const handleNextStep = () => {
-    setCurStep((prev) => (prev === TOTAL_STEPS ? TOTAL_STEPS : prev + 1));
-    setCurPercent(curPercent < 100 ? curPercent + PERCENTAGE : curPercent);
-  };
 
   return (
     <Container>
       <HeaderLogo src={headerLogo} onClick={() => navigate('/')} />
       <Line
-        percent={curPercent}
+        percent={Number(step) * PERCENTAGE}
         strokeWidth={3}
         trailWidth={3}
         strokeColor="var(--primary)"
@@ -57,20 +43,22 @@ const Select = () => {
       )}
       <BtnContainer>
         <Button
-          to={`/select/${curStep === 1 ? 1 : curStep - 1}`}
-          onClick={handlePrevStep}
+          to={`/select/${step === '1' ? 1 : Number(step) - 1}`}
           prev={true.toString()}
           disabled={step === '1'}
         >
           이전
         </Button>
         <Button
-          to={`/select/${curStep === TOTAL_STEPS ? TOTAL_STEPS : curStep + 1}`}
-          onClick={handleNextStep}
+          to={`/select/${
+            step === String(TOTAL_STEPS) ? TOTAL_STEPS : Number(step) + 1
+          }`}
           disabled={
             step === String(TOTAL_STEPS) ||
             !Boolean(
-              selectedState[SELECTED_STEPS[curStep - 1] as keyof SelectedProps],
+              selectedState[
+                SELECTED_STEPS[Number(step) - 1] as keyof SelectedProps
+              ],
             )
           }
         >

--- a/src/pages/select.tsx
+++ b/src/pages/select.tsx
@@ -1,12 +1,7 @@
 import styled from 'styled-components';
-import { FormEvent, useState } from 'react';
+import { useState } from 'react';
 import { Line } from 'rc-progress';
 import headerLogo from '../assets/header.png';
-import FirstStep from '../components/selectItem/FirstStep';
-import SecondStep from '../components/selectItem/SecondStep';
-import ThirdStep from '../components/selectItem/ThirdStep';
-import FourthStep from '../components/selectItem/FourthStep';
-import WebcamCapture from '../components/WebcamCapture';
 import ImageFileUpload from '../components/ImageUpload';
 import { SelectedProps } from '../api/types';
 import { Link, useNavigate, useParams } from 'react-router-dom';
@@ -14,15 +9,8 @@ import SelectItem from '../components/SelectItem';
 import { useRecoilValue } from 'recoil';
 import { selectedAtom } from '../atoms';
 
-interface ButtonProps {
-  prev?: string;
-  disabled?: boolean;
-}
-
 const TOTAL_STEPS = 5;
-const STEP = 5;
-const PERCENTAGE = 100 / STEP;
-
+const PERCENTAGE = 100 / TOTAL_STEPS;
 const SELECTED_STEPS = ['season', 'weather', 'feel', 'travel', 'photo'];
 
 const Select = () => {
@@ -31,33 +19,25 @@ const Select = () => {
   const [curStep, setCurStep] = useState(Number(step));
   const selectedState = useRecoilValue(selectedAtom);
 
-  const [currentStep, setCurrentStep] = useState<number>(PERCENTAGE);
-  const [uploadType, setUploadType] = useState('');
+  const [curPercent, setCurPercent] = useState(PERCENTAGE);
 
   const handlePrevStep = () => {
     setCurStep((prev) => (prev === 1 ? 1 : prev - 1));
-    setCurrentStep(
-      currentStep > PERCENTAGE ? currentStep - PERCENTAGE : currentStep,
+    setCurPercent(
+      curPercent > PERCENTAGE ? curPercent - PERCENTAGE : curPercent,
     );
   };
 
   const handleNextStep = () => {
     setCurStep((prev) => (prev === TOTAL_STEPS ? TOTAL_STEPS : prev + 1));
-    setCurrentStep(currentStep < 100 ? currentStep + PERCENTAGE : currentStep);
-  };
-
-  const handleUploadBtn = (e: FormEvent<HTMLButtonElement>) => {
-    const {
-      currentTarget: { value },
-    } = e;
-    setUploadType(value);
+    setCurPercent(curPercent < 100 ? curPercent + PERCENTAGE : curPercent);
   };
 
   return (
     <Container>
       <HeaderLogo src={headerLogo} onClick={() => navigate('/')} />
       <Line
-        percent={currentStep}
+        percent={curPercent}
         strokeWidth={3}
         trailWidth={3}
         strokeColor="var(--primary)"
@@ -72,26 +52,7 @@ const Select = () => {
         <>
           <StepTitle>나와 닮은 못난이 캐릭터를 찾아보세요</StepTitle>
           <StepSubText>얼굴이 잘리지 않은 사진을 업로드해주세요</StepSubText>
-          {uploadType === 'upload' && <ImageFileUpload />}
-          {uploadType === 'capture' && <WebcamCapture />}
-
-          {!uploadType && (
-            <UploadBtnContainer>
-              <UploadButton value="upload" onClick={handleUploadBtn}>
-                사진 업로드
-              </UploadButton>
-              <UploadButton
-                value="capture"
-                onClick={() =>
-                  alert(
-                    'HTTPS 보안 문제로 현재 기기에서 사용할 수 없는 기능입니다. \n업데이트 예정입니다 :)',
-                  )
-                }
-              >
-                사진 촬영
-              </UploadButton>
-            </UploadBtnContainer>
-          )}
+          <ImageFileUpload />
         </>
       )}
       <BtnContainer>
@@ -153,7 +114,7 @@ const BtnContainer = styled.div`
   margin: 59px 0 125px 0;
 `;
 
-const Button = styled(Link)<ButtonProps>`
+const Button = styled(Link)<{ prev?: string; disabled: boolean }>`
   width: 79px;
   height: 52px;
   background-color: ${(props) =>

--- a/src/pages/select.tsx
+++ b/src/pages/select.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { useState } from 'react';
 import { Line } from 'rc-progress';
 import headerLogo from '../assets/header.png';
 import ImageFileUpload from '../components/ImageUpload';
@@ -18,6 +17,13 @@ const Select = () => {
   const navigate = useNavigate();
   const { step } = useParams();
   const selectedState = useRecoilValue(selectedAtom);
+
+  const disabledPrevBtn = step === '1';
+  const disabledNextBtn =
+    step === String(TOTAL_STEPS) ||
+    !Boolean(
+      selectedState[SELECTED_STEPS[Number(step) - 1] as keyof SelectedProps],
+    );
 
   return (
     <Container>
@@ -43,24 +49,19 @@ const Select = () => {
       )}
       <BtnContainer>
         <Button
-          to={`/select/${step === '1' ? 1 : Number(step) - 1}`}
+          to={
+            disabledPrevBtn ? `/select/${step}` : `/select/${Number(step) - 1}`
+          }
           prev={true.toString()}
-          disabled={step === '1'}
+          disabled={disabledPrevBtn}
         >
           이전
         </Button>
         <Button
-          to={`/select/${
-            step === String(TOTAL_STEPS) ? TOTAL_STEPS : Number(step) + 1
-          }`}
-          disabled={
-            step === String(TOTAL_STEPS) ||
-            !Boolean(
-              selectedState[
-                SELECTED_STEPS[Number(step) - 1] as keyof SelectedProps
-              ],
-            )
+          to={
+            disabledNextBtn ? `/select/${step}` : `/select/${Number(step) + 1}`
           }
+          disabled={disabledNextBtn}
         >
           다음
         </Button>

--- a/src/pages/select.tsx
+++ b/src/pages/select.tsx
@@ -10,6 +10,7 @@ import WebcamCapture from '../components/WebcamCapture';
 import ImageFileUpload from '../components/ImageUpload';
 import { SelectedProps } from '../api/types';
 import { useNavigate } from 'react-router-dom';
+import SelectItem from '../components/SelectItem';
 
 interface ButtonProps {
   label?: string;
@@ -63,10 +64,10 @@ const Select = () => {
         trailColor="var(--progress-trail)"
         style={{ width: '333px', marginTop: '46px' }}
       />
-      {currentStep === 20 && <FirstStep />}
-      {currentStep === 40 && <SecondStep />}
-      {currentStep === 60 && <ThirdStep />}
-      {currentStep === 80 && <FourthStep />}
+      {currentStep === 20 && <SelectItem step={1} />}
+      {currentStep === 40 && <SelectItem step={2} />}
+      {currentStep === 60 && <SelectItem step={3} />}
+      {currentStep === 80 && <SelectItem step={4} />}
       {currentStep === 100 && (
         <>
           <StepTitle>나와 닮은 못난이 캐릭터를 찾아보세요</StepTitle>

--- a/src/pages/select.tsx
+++ b/src/pages/select.tsx
@@ -9,40 +9,40 @@ import FourthStep from '../components/selectItem/FourthStep';
 import WebcamCapture from '../components/WebcamCapture';
 import ImageFileUpload from '../components/ImageUpload';
 import { SelectedProps } from '../api/types';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import SelectItem from '../components/SelectItem';
+import { useRecoilValue } from 'recoil';
+import { selectedAtom } from '../atoms';
 
 interface ButtonProps {
-  label?: string;
-  prev?: boolean;
-  onClick?: () => void;
+  prev?: string;
+  disabled?: boolean;
 }
 
+const TOTAL_STEPS = 5;
 const STEP = 5;
 const PERCENTAGE = 100 / STEP;
 
-const steps = ['season', 'weather', 'feel', 'travel', 'photo'];
+const SELECTED_STEPS = ['season', 'weather', 'feel', 'travel', 'photo'];
 
 const Select = () => {
   const navigate = useNavigate();
+  const { step } = useParams();
+  const [curStep, setCurStep] = useState(Number(step));
+  const selectedState = useRecoilValue(selectedAtom);
 
   const [currentStep, setCurrentStep] = useState<number>(PERCENTAGE);
   const [uploadType, setUploadType] = useState('');
 
-  const isActivePrevBtn = currentStep !== PERCENTAGE;
-  //TODO: 다음 버튼 활성화 로직 수정 필요
-  const isActiveNextBtn = currentStep !== 100;
-  // Boolean(
-  //   selectedState[steps[currentStep / PERCENTAGE - 1] as SelectedProps],
-  // );
-
   const handlePrevStep = () => {
+    setCurStep((prev) => (prev === 1 ? 1 : prev - 1));
     setCurrentStep(
       currentStep > PERCENTAGE ? currentStep - PERCENTAGE : currentStep,
     );
   };
 
   const handleNextStep = () => {
+    setCurStep((prev) => (prev === TOTAL_STEPS ? TOTAL_STEPS : prev + 1));
     setCurrentStep(currentStep < 100 ? currentStep + PERCENTAGE : currentStep);
   };
 
@@ -64,11 +64,11 @@ const Select = () => {
         trailColor="var(--progress-trail)"
         style={{ width: '333px', marginTop: '46px' }}
       />
-      {currentStep === 20 && <SelectItem step={1} />}
-      {currentStep === 40 && <SelectItem step={2} />}
-      {currentStep === 60 && <SelectItem step={3} />}
-      {currentStep === 80 && <SelectItem step={4} />}
-      {currentStep === 100 && (
+      {step === '1' && <SelectItem step={1} />}
+      {step === '2' && <SelectItem step={2} />}
+      {step === '3' && <SelectItem step={3} />}
+      {step === '4' && <SelectItem step={4} />}
+      {step === '5' && (
         <>
           <StepTitle>나와 닮은 못난이 캐릭터를 찾아보세요</StepTitle>
           <StepSubText>얼굴이 잘리지 않은 사진을 업로드해주세요</StepSubText>
@@ -96,17 +96,22 @@ const Select = () => {
       )}
       <BtnContainer>
         <Button
-          label="Prev Step"
-          prev
+          to={`/select/${curStep === 1 ? 1 : curStep - 1}`}
           onClick={handlePrevStep}
-          disabled={!isActivePrevBtn}
+          prev={true.toString()}
+          disabled={step === '1'}
         >
           이전
         </Button>
         <Button
-          label="Next Step"
+          to={`/select/${curStep === TOTAL_STEPS ? TOTAL_STEPS : curStep + 1}`}
           onClick={handleNextStep}
-          disabled={!isActiveNextBtn}
+          disabled={
+            step === String(TOTAL_STEPS) ||
+            !Boolean(
+              selectedState[SELECTED_STEPS[curStep - 1] as keyof SelectedProps],
+            )
+          }
         >
           다음
         </Button>
@@ -148,7 +153,7 @@ const BtnContainer = styled.div`
   margin: 59px 0 125px 0;
 `;
 
-const Button = styled.button<ButtonProps>`
+const Button = styled(Link)<ButtonProps>`
   width: 79px;
   height: 52px;
   background-color: ${(props) =>

--- a/src/static/select.ts
+++ b/src/static/select.ts
@@ -1,0 +1,86 @@
+export const SELECT_OPTIONS = [
+  {
+    name: 'season',
+    subTitle: '일주일 간 제주로 여행을 떠난다면...',
+    title: '어떤 계절에 떠나시겠어요?',
+    item1: {
+      value: 'spring',
+      text: '왕벚꽃이 펼쳐진 따뜻한 봄의 제주',
+    },
+    item2: {
+      value: 'summer',
+      text: '에너지가 넘치는 여름의 제주',
+    },
+    item3: {
+      value: 'fall',
+      text: '감성 넘치는 단풍이 있는 가을의 제주',
+    },
+    item4: {
+      value: 'winter',
+      text: '한 해를 마무리하는 연말 겨울의 제주',
+    },
+  },
+  {
+    name: 'weather',
+    subTitle: '난 햇빛을 받으면 ... 기분이 좋아지곤 해 ...',
+    title: '가장 좋아하는 날씨가 있다면?',
+    item1: {
+      value: 'normal',
+      text: '바람 한 점 없는 고요한 날씨',
+    },
+    item2: {
+      value: 'sunny',
+      text: '햇빛이 잘 드는 따뜻한 날씨',
+    },
+    item3: {
+      value: 'rainny',
+      text: '비가 내리는 센치한 날씨',
+    },
+    item4: {
+      value: 'snowy',
+      text: '눈이 펑펑오는 낭만적인 날씨',
+    },
+  },
+  {
+    name: 'feel',
+    subTitle: '지금 이 질문을 본 당신!',
+    title: '오늘 당신의 기분은 어떠신가요?',
+    item1: {
+      value: 'energetic',
+      text: '활기차고 에너지가 넘쳐요',
+    },
+    item2: {
+      value: 'angry',
+      text: '화나는 일이 있어요',
+    },
+    item3: {
+      value: 'tired',
+      text: '힐링이 필요해요',
+    },
+    item4: {
+      value: 'normal',
+      text: '대체적으로 평범해요',
+    },
+  },
+  {
+    name: 'travel',
+    subTitle: '제주 여행을 가게 된 당신!',
+    title: '제주 여행의 테마를 골라주세요!',
+    item1: {
+      value: 'shopping',
+      text: '소비가 최고! 쇼핑을 즐기자',
+    },
+    item2: {
+      value: 'running',
+      text: '바다앞에서 러닝하는 건강루틴 실천',
+    },
+    item3: {
+      value: 'coffee',
+      text: '분위기 좋은 카페에서 커피 한 잔!',
+    },
+    item4: {
+      value: 'eating',
+      text: '맛집이 최고지~ 맛집 코스 여행',
+    },
+  },
+];


### PR DESCRIPTION
## refact: select 페이지 라우팅 및 리팩토링- #38
Resolve #38 

## summary
- `usestate`로 관리하던 스텝을 페이지로 빼서 라우팅했습니다. (이렇게 한 이유는 새로고침 했을 때 현재 선택지에 남아있을 수 있도록 하기 위해서 입니당)
- select 페이지의 불필요한 변수들 및 로직을 정리했습니다. 리뷰하시다 이해안되시는 부분은 코멘트로 마구 남겨주세요!
- `SelectItem`이라는 컴포넌트를 만들어서, 현재 `selectItem`폴더 하위에 있는 각 스텝 컴포넌트는 제거하면 됩니다. 근데 리뷰 시 비교하시라고 남겨두었고, 나중에 별도로 삭제하면 될 것 같아요~
- 웹캠 제거했습니다.
- 스타일은 건들이지 않았습니다! 업데이트된 피그마 반영은 지민님이 작업 중이시라 충돌날까봐 일단 그냥 냅뒀습니다.

## Check List
- [x] PR 제목 commit convention에 맞게 작성
- [x] 최신 상태를 반영하고 있는지 확인
- [x] assignees & label 지정 
- [x] 웃으면서 하고 있는지 확인
- [x] 지금 행복한지 확인
