### PR TITLE
feat: Header Component - #70

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import Router from './components/router';
+import Router from './components/Router';
 import { GlobalStyle } from './style/global';
 import './style/color.css';
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+import headerLogo from '../assets/header.png';
+import { useNavigate } from 'react-router-dom';
+
+const Header = () => {
+  const navigate = useNavigate();
+  return <HeaderLogo src={headerLogo} onClick={() => navigate('/')} />;
+};
+
+export default Header;
+
+const HeaderLogo = styled.img`
+  width: 17px;
+  cursor: pointer;
+`;

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -2,10 +2,10 @@ import { FormEvent, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { handleKaKaoShareBtn } from '../utils/kakaoShare';
 import { handleImageDownload } from '../utils/ImageDownload';
-import headerLogo from '../assets/header.png';
 import introductionImg from '../assets/introduction.svg';
 import { QUOTE } from '../static/quote';
 import { IMAGE_URLS, PRODUCT_IMAGES } from '../static/image';
+import Header from '../components/Header';
 import styled from 'styled-components';
 
 import type { ResultProps } from '../api/types';
@@ -27,7 +27,7 @@ function Result() {
 
   return (
     <FlexBox>
-      <HeaderLogo src={headerLogo} />
+      <Header />
       <ResultImage src={PRODUCT_IMAGES[result.type]} alt="result-image" />
 
       <ResultSubName>나는 못난이</ResultSubName>
@@ -120,11 +120,6 @@ const FlexBox = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-`;
-
-const HeaderLogo = styled.img`
-  width: 17px;
-  margin: 0 auto;
 `;
 
 const ResultImage = styled.img`

--- a/src/pages/select.tsx
+++ b/src/pages/select.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import { Line } from 'rc-progress';
-import headerLogo from '../assets/header.png';
 import ImageFileUpload from '../components/ImageUpload';
 import { SelectedProps } from '../api/types';
 import { Link, useNavigate, useParams } from 'react-router-dom';
@@ -11,6 +10,7 @@ import { getResult } from '../api';
 import { useMutation } from 'react-query';
 import Loading from '../components/Loading';
 import { useEffect } from 'react';
+import Header from '../components/Header';
 
 //TODO: static으로 빼기
 const TOTAL_STEPS = 5;
@@ -57,7 +57,7 @@ const Select = () => {
 
   return (
     <Container>
-      <HeaderLogo src={headerLogo} onClick={() => navigate('/')} />
+      <Header />
       <Line
         percent={Number(step) * PERCENTAGE}
         strokeWidth={3}
@@ -103,11 +103,6 @@ const Select = () => {
 };
 
 export default Select;
-
-const HeaderLogo = styled.img`
-  width: 17px;
-  cursor: pointer;
-`;
 
 const ButtonType = {
   bgcolor: {


### PR DESCRIPTION
## feat: Header Component - #70
Resolve #70 

## summary
- `select`와 `result`에 각각 있던 헤더를 컴포넌트로 이동

## Check List
- [x] PR 제목 commit convention에 맞게 작성
- [x] 최신 상태를 반영하고 있는지 확인
- [x] assignees & label 지정 
- [x] 웃으면서 하고 있는지 확인
- [x] 지금 행복한지 확인
