### PR TITLE
feat: layout shift 개선 - #75

### DIFF
--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -77,6 +77,7 @@ const FileInput = styled.input`
 
 const CameraImg = styled.img`
   width: 32px;
+  height: 32px;
   margin-bottom: 14px;
 `;
 
@@ -92,7 +93,7 @@ const FileSelctButton = styled.button`
   font-family: 'Noto Sank KR';
   font-size: 16px;
   font-weight: 400;
-  margin-top: 96px;
+  margin-top: 75px;
   cursor: pointer;
 `;
 

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -124,6 +124,7 @@ const FlexBox = styled.div`
 
 const ResultImage = styled.img`
   width: 100%;
+  height: 315px;
   display: block;
   align-self: center;
   margin-top: 30px;
@@ -151,6 +152,7 @@ const ResultDescription = styled.div`
 
 const DescriptionImage = styled.img`
   width: 100%;
+  height: 400px;
   margin: 48px 0 68px 0;
 `;
 


### PR DESCRIPTION
## feat: layout shift 개선 - #75
Resolve #75 

## summary
- 결과 페이지와 이미지 업로드 layout shift 현상 개선
- 이미지 업로드 페이지에서 이전/다음 버튼 위치 다른 페이지와 동일하게 맞춤 (`margin-top` 조절)

**BEFORE**

https://user-images.githubusercontent.com/42757774/235063163-55db7717-0b23-4819-b186-0e4faac7bfa1.mov

**AFTER**

https://user-images.githubusercontent.com/42757774/235063202-10400a9b-7902-48e0-b07d-6ebcac6a58f5.mov


## Check List
- [x] PR 제목 commit convention에 맞게 작성
- [x] 최신 상태를 반영하고 있는지 확인
- [x] assignees & label 지정 
- [x] 웃으면서 하고 있는지 확인
- [x] 지금 행복한지 확인
