### PR TITLE
design: 랜딩 페이지 상단 마진 수정 - #94

### DIFF
--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -50,7 +50,7 @@ export default Home;
 
 const Body = styled.div`
   text-align: center;
-  margin-top: 20px;
+  margin-top: 3vh;
 `;
 
 const Image = styled.img`

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -50,7 +50,6 @@ export default Home;
 
 const Body = styled.div`
   text-align: center;
-  margin-top: 50px;
 `;
 
 const Image = styled.img`

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -50,6 +50,7 @@ export default Home;
 
 const Body = styled.div`
   text-align: center;
+  margin-top: 20px;
 `;
 
 const Image = styled.img`


### PR DESCRIPTION
## Title
Resolve #94 

## summary
home 페이지가 전반적으로 아래쪽에 쏠려있는 이슈를 해결하였습니다!
<img width="574" alt="image" src="https://github.com/monnani-girl/nomonnani-FE/assets/66112716/8bc747d1-e26b-469f-8480-04bd1c555127">

## Check List
- [x] PR 제목 commit convention에 맞게 작성
- [x] 최신 상태를 반영하고 있는지 확인
- [x] assignees & label 지정 
- [x] 웃으면서 하고 있는지 확인
- [x] 지금 행복한지 확인
