### PR TITLE
design: 문답 페이지 사이즈 축소 - #97

### DIFF
--- a/src/components/SelectItems.tsx
+++ b/src/components/SelectItems.tsx
@@ -38,7 +38,7 @@ const SubTitle = styled.div`
   font-style: normal;
   font-size: 16px;
   line-height: 24px;
-  margin-top: 48px;
+  margin-top: 30px;
 `;
 
 const Title = styled.div`
@@ -46,7 +46,7 @@ const Title = styled.div`
   line-height: 24px;
   letter-spacing: 0em;
   text-align: center;
-  margin: 10px 0 34px 0;
+  margin: 10px 0 20px 0;
   color: var(--black);
 `;
 

--- a/src/pages/select.tsx
+++ b/src/pages/select.tsx
@@ -76,7 +76,7 @@ const Select = () => {
         trailWidth={3}
         strokeColor="var(--primary)"
         trailColor="var(--progress-trail)"
-        style={{ maxWidth: '333px', marginTop: '46px' }}
+        style={{ maxWidth: '333px', marginTop: '30px' }}
       />
 
       {step &&
@@ -137,7 +137,7 @@ const BtnContainer = styled.div`
   width: 100%;
   display: flex;
   justify-content: space-between;
-  margin-top: 60px;
+  margin-top: 30px;
 `;
 
 const Button = styled(Link)<{


### PR DESCRIPTION
## Title
Resolve #97 

## summary
문답 페이지(`Select`)에서 버튼 클릭 시 스크롤링이 필요한 이슈를 
헤더 및 버튼 마진 값 수정을 통해 개선하였습니다.

- 높이가 가장 작은 iPhone SE 반응형(height 667px)에서의 실행 화면
<img width="574" alt="image" src="https://github.com/monnani-girl/nomonnani-FE/assets/66112716/e915eb58-73e0-49fd-b13a-a6d2cd67ae87">

## Check List
- [x] PR 제목 commit convention에 맞게 작성
- [x] 최신 상태를 반영하고 있는지 확인
- [x] assignees & label 지정 
- [x] 웃으면서 하고 있는지 확인
- [x] 지금 행복한지 확인
