### PR TITLE
refactor: 이미지 업로드 UX Writing & 배율 수정 - #95

### DIFF
--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -51,20 +51,18 @@ const ImageFileUpload = ({ onClickButton }: ImageFileUploadProps) => {
           ref={inputRef}
           onChange={handleImageChange}
         />
-        {imageSrc ? (
-          <Image src={imageSrc} alt="uploaded-file" />
-        ) : (
-          <FileSelctButton onClick={handleUploadClick}>
-            <CameraImg src={camera} alt="camera" />
-            <br />
-            얼굴이 잘리지 않은 <br />
-            사진을 올려주세요
-            <PointText>
-              click!
-            </PointText>
-          </FileSelctButton>
-        )}
       </label>
+      {imageSrc ? (
+        <Image src={imageSrc} alt="uploaded-file" />
+      ) : (
+        <FileSelctButton onClick={handleUploadClick}>
+          <CameraImg src={camera} alt="camera" />
+          <br />
+          얼굴이 잘리지 않은 <br />
+          사진을 올려주세요
+          <PointText>click!</PointText>
+        </FileSelctButton>
+      )}
       <FindButton onClick={onClickButton} disabled={Boolean(!imageSrc)}>
         닮은꼴 찾기
       </FindButton>
@@ -87,15 +85,15 @@ const CameraImg = styled.img`
 const FileSelctButton = styled.button`
   width: 198px;
   height: 198px;
+  margin-top: 54px;
+  border: 1px solid #e1e1e1;
+  border-radius: 20px;
   background-color: var(--white);
   color: var(--darkgrey);
   line-height: 21px;
-  border: 1px solid #e1e1e1;
-  border-radius: 20px;
   font-family: 'Noto Sank KR';
   font-size: 16px;
   font-weight: 400;
-  margin-top: 54px;
   cursor: pointer;
 `;
 
@@ -104,7 +102,7 @@ const FindButton = styled.button<{ disabled: boolean }>`
   height: 72px;
   font-family: 'GmarketSansMedium';
   font-size: 24px;
-  margin-top: ${(props) => (props.disabled ? '40px' : '32px')};
+  margin-top: 40px;
   color: var(--white);
   background-color: var(--primary);
   border-radius: 100px;
@@ -123,7 +121,7 @@ const Image = styled.img`
 `;
 
 const PointText = styled.p`
-  color: #FF8D4D;
+  color: #ff8d4d;
   font-size: 16px;
-  font-family: "Noto Sans KR";
+  font-family: 'Noto Sans KR';
 `;

--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -108,7 +108,7 @@ const FindButton = styled.button<{ disabled: boolean }>`
   height: 72px;
   font-family: 'GmarketSansMedium';
   font-size: 24px;
-  margin-top: 40px;
+  margin-top: ${(props) => (props.disabled ? '40px' : '32px')};
   color: var(--white);
   background-color: var(--primary);
   border-radius: 100px;
@@ -120,6 +120,8 @@ const Image = styled.img`
   width: 198px;
   height: 198px;
   border-radius: 20px;
-  margin-top: 96px;
-  object-fit: contain;
+  margin-top: 54px;
+  border: 1px solid #e1e1e1;
+  object-fit: cover;
+  object-position: center;
 `;

--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -59,6 +59,13 @@ const ImageFileUpload = ({ onClickButton }: ImageFileUploadProps) => {
             <br />
             얼굴이 잘리지 않은 <br />
             사진을 올려주세요
+            <p style={{
+              color: "#FF8D4D",
+              fontSize: "16px",
+              fontFamily: "Noto Sans KR",
+            }}>
+              click!
+            </p>
           </FileSelctButton>
         )}
       </label>
@@ -89,11 +96,10 @@ const FileSelctButton = styled.button`
   line-height: 21px;
   border: 1px solid #e1e1e1;
   border-radius: 20px;
-  box-shadow: 3px 3px 5px #e1e1e1;
   font-family: 'Noto Sank KR';
   font-size: 16px;
   font-weight: 400;
-  margin-top: 75px;
+  margin-top: 54px;
   cursor: pointer;
 `;
 
@@ -115,6 +121,5 @@ const Image = styled.img`
   height: 198px;
   border-radius: 20px;
   margin-top: 96px;
-  box-shadow: 3px 3px 5px #e1e1e1;
   object-fit: contain;
 `;

--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -59,13 +59,9 @@ const ImageFileUpload = ({ onClickButton }: ImageFileUploadProps) => {
             <br />
             얼굴이 잘리지 않은 <br />
             사진을 올려주세요
-            <p style={{
-              color: "#FF8D4D",
-              fontSize: "16px",
-              fontFamily: "Noto Sans KR",
-            }}>
+            <PointText>
               click!
-            </p>
+            </PointText>
           </FileSelctButton>
         )}
       </label>
@@ -124,4 +120,10 @@ const Image = styled.img`
   border: 1px solid #e1e1e1;
   object-fit: cover;
   object-position: center;
+`;
+
+const PointText = styled.p`
+  color: #FF8D4D;
+  font-size: 16px;
+  font-family: "Noto Sans KR";
 `;

--- a/src/pages/select.tsx
+++ b/src/pages/select.tsx
@@ -85,6 +85,7 @@ const Select = () => {
         ) : (
           <>
             <StepTitle>나와 닮은 못난이 캐릭터를 찾아보세요</StepTitle>
+            <NotiText>걱정마세요! 사진은 별도로 저장되지 않습니다.</NotiText>
             <ImageFileUpload onClickButton={handleCaptureClick} />
           </>
         ))}
@@ -177,5 +178,11 @@ const Button = styled(Link)<{
 
 const StepTitle = styled.div`
   font-size: 20px;
-  margin-top: 77px;
+  margin-top: 50px;
+`;
+
+const NotiText = styled.div`
+  color: var(--sub-black);
+  font-size: 14px;
+  margin-top: 18px;
 `;


### PR DESCRIPTION
## Title
Resolve #95 

## summary
- 이미지 업로드 페이지에서의 ux writing을 추가하였습니다.
- 업로드 버튼 내부의 `click!` ux writing을 추가하였습니다.
- 이미지 업로드 시 좌우 또는 상하에 배율에 따른 여백이 생겨나는 현상을 해결하였습니다.
    - 이미지의 배율을 유지하되, 이미지 업로드 버튼의 크기를 넘어가는 부분의 경우 crop하는 형식으로 변경하였습니다.
- 이미지 업로드 시 `닮은꼴 찾기`버튼이 하단으로 밀리는 현상을 해결하였습니다.

https://github.com/monnani-girl/nomonnani-FE/assets/66112716/6f87379e-7319-4cd6-afbb-72765266f8d4


## Check List
- [x] PR 제목 commit convention에 맞게 작성
- [x] 최신 상태를 반영하고 있는지 확인
- [x] assignees & label 지정 
- [x] 웃으면서 하고 있는지 확인
- [x] 지금 행복한지 확인
